### PR TITLE
User home PATH and Helm version UPDATE.

### DIFF
--- a/lab3_helm_install/README.md
+++ b/lab3_helm_install/README.md
@@ -36,7 +36,7 @@ tiller
 
 sudo mv linux-amd64/helm /usr/local/bin/helm
 helm init --client-only
-export HELM_HOME=/home/me/.helm
+export HELM_HOME=/home/$(whoami)/.helm
 helm version --short
 export HELM_HOST=localhost:44134
 helm version --short

--- a/lab3_helm_install/README.md
+++ b/lab3_helm_install/README.md
@@ -14,8 +14,8 @@ minikube start
 ```
 ## Helm installation
 ```
-curl -LO https://storage.googleapis.com/kubernetes-helm/helm-v2.13.1-linux-amd64.tar.gz
-tar -zxvf helm-v2.13.1-linux-amd64.tar.gz
+curl -LO https://storage.googleapis.com/kubernetes-helm/helm-v2.14.3-linux-amd64.tar.gz
+tar -zxvf helm-v2.14.3-linux-amd64.tar.gz
 sudo mv linux-amd64/helm /usr/local/bin/helm
 
 helm version --short
@@ -29,8 +29,8 @@ kubectl get all | grep nginx-demo
 ```
 ## Helm local tiller
 ```
-curl -LO https://storage.googleapis.com/kubernetes-helm/helm-v2.13.1-linux-amd64.tar.gz 
-tar -zxvf helm-v2.13.1-linux-amd64.tar.gz
+curl -LO https://storage.googleapis.com/kubernetes-helm/helm-v2.14.3-linux-amd64.tar.gz 
+tar -zxvf helm-v2.14.3-linux-amd64.tar.gz
 sudo mv linux-amd64/tiller /usr/local/bin/tiller
 tiller
 


### PR DESCRIPTION
`Updated helm version to latest stable

Between 2.13.1 and 2.14.3 has been done a lot of bug fixes and since you are downloading minikube latest version it would be better to get lets helm.
Release notes : https://github.com/helm/helm/releases`

`User home PATH update.

Added a more dynamic version for user's home path to be used.`